### PR TITLE
AMDC REVF README information standardization

### DIFF
--- a/REV20231005F/README.md
+++ b/REV20231005F/README.md
@@ -1,25 +1,39 @@
 # AMDC REV20231010F
 
-This folder contains the compiled design outputs for AMDC REV F (design frozen on October 10, 2023). This includes the schematics, images of the PCB layout, the bill of materials (BOM), and the files needed to order fully populated boards from an online vendor.
+This folder contains the compiled design outputs for AMDC REV F. This includes the schematics, images of the PCB layout, the bill of materials (BOM), and the files needed to order fully populated boards from an online vendor.
 
 ## Board Parameters
 
+| Question                | Answer           |
+|-------------------------|------------------|
+| Board Size              | 6" x 6.75"       |
+| Numer of Layers         | 6 Layers         |
+| Double Sided            | Yes              |
+| Surface Finish          | Tin Lead         |
+| Silkscreen              | White            |
+| Material                | FR-4, TG150      |
+| Board Thickness	      | 1.6 mm           |
+| Min Trace Spacing       | 0.15 mm (6 mil)  |
+| Min Hole Size           | 0.36 mm (14 mil) |
+| Number of Holes         | 1528             |
+| Solder Mask	          | Green            |
+| Finished Copper         | 1 oz             |
+
+## Assembly Details
+
 | Question                   | Answer      |
 |----------------------------|-------------|
-| Unique Part Count          | 69          |
-| Total Placements           | 448         |
+| Unique Part Count[^1]      | 69          |
+| Number of Total Parts[^1]  | 458         |
 | Total SMT Part Count       | 416         |
-| Total SOP/QFP/QFN/BGA      | 52          |
 | Total Thru Hole Part Count | 32          |
+| Total Mechanical Screws    | 13          |
+| Total Mechanical Standoffs | 13          |
 | BGA / QFN                  | Yes         |
-| Double Sided               | Yes         |
+| Total SOP/QFP/QFN/BGA      | 52          |
 
-| Question                | Answer      |
-|-------------------------|-------------|
-| Board Size (H x W)      | 6" x 6.75"  |
-| Numer of Layers         | 6           |
-| Number of Holes         | 1528        |
-| Number of Slots/Cutouts | 0           |
-| Surface Finish          | Tin Lead    |
-| Silkscreen              | Both Sides  |
-| Electrical Test         | Yes         |
+## Bill of Materials
+
+The [Bill of Materials (BOM)](bom-rev-f.csv) contains components for 1 board. If users of this repo discover that any components are unvailable, please maintain an `alternate-components.md` file in this folder that lists approved alternates.
+
+[^1]: This number does not include screws or standoffs. With screws and standoffs included, the unique part count is 71 and total parts is 484. Users are advised to not have their assembly vendor place screws and standoffs.

--- a/REV20231005F/README.md
+++ b/REV20231005F/README.md
@@ -17,24 +17,27 @@ This folder contains the compiled design outputs for AMDC REV F. This includes t
 | Min Hole Size           | 0.36 mm (14 mil) |
 | Number of Holes         | 1528             |
 | Solder Mask             | Green            |
+| HASL or ENIG            | No               |
 | Finished Copper         | 1 oz             |
 
 ## Assembly Details
 
-| Question                   | Answer      |
-|----------------------------|-------------|
-| Unique Part Count[^1]      | 67          |
-| Number of Total Parts[^1]  | 447         |
-| Total SMT Part Count       | 415         |
-| Total Thru Hole Part Count | 32          |
-| Total Mechanical Screws    | 13          |
-| Total Mechanical Standoffs | 13          |
-| Total Removable Jumpers    | 10          |
-| Total Picozed              | 1           |
-| BGA / QFN                  | Yes         |
+| Question[^1]                  | Answer      |
+|-------------------------------|-------------|
+| Unique Part Count[^2]         | 67          |
+| Number of Total Parts[^2]     | 447         |
+| Total SMT Part Count          | 415         |
+| Total Through-hole Part Count | 32          |
+| Total Mechanical Screws       | 13          |
+| Total Mechanical Standoffs    | 13          |
+| Total Removable Jumpers       | 10          |
+| Total Picozed                 | 1           |
+| BGA / QFN                     | Yes         |
 
 ## Bill of Materials
 
 The [Bill of Materials (BOM)](bom-rev-f.csv) contains components for 1 board. If users of this repo discover that any components are unvailable, please maintain an `alternate-components.md` file in this folder that lists approved alternates.
 
-[^1]: This number does not include screws, standoffs, removable jumpers, or the picozed. With these components included, the unique part count is 71 and total parts is 484. Users are advised to not have their assembly vendor place these components.
+[^1]: For complete breakdown of surface mount, through-hole, and other components, see [this pull request comment](https://github.com/Severson-Group/AMDC-Hardware/pull/255#issuecomment-2815977355)
+
+[^2]: This number does not include screws, standoffs, removable jumpers, or the picozed. With these components included, the unique part count is 71 and total parts is 484. Users are advised to not have their assembly vendor place these components.

--- a/REV20231005F/README.md
+++ b/REV20231005F/README.md
@@ -23,17 +23,17 @@ This folder contains the compiled design outputs for AMDC REV F. This includes t
 
 | Question                   | Answer      |
 |----------------------------|-------------|
-| Unique Part Count[^1]      | 69          |
-| Number of Total Parts[^1]  | 458         |
-| Total SMT Part Count       | 416         |
-| Total Thru Hole Part Count | 32          |
+| Unique Part Count[^1]      | 67          |
+| Number of Total Parts[^1]  | 447         |
+| Total SMT Part Count       | 418         |
+| Total Thru Hole Part Count | 29          |
 | Total Mechanical Screws    | 13          |
 | Total Mechanical Standoffs | 13          |
+| Total Removable Jumpers    | 10          |
 | BGA / QFN                  | Yes         |
-| Total SOP/QFP/QFN/BGA      | 52          |
 
 ## Bill of Materials
 
 The [Bill of Materials (BOM)](bom-rev-f.csv) contains components for 1 board. If users of this repo discover that any components are unvailable, please maintain an `alternate-components.md` file in this folder that lists approved alternates.
 
-[^1]: This number does not include screws or standoffs. With screws and standoffs included, the unique part count is 71 and total parts is 484. Users are advised to not have their assembly vendor place screws and standoffs.
+[^1]: This number does not include screws, standoffs, removable jumpers, or the picozed. With these components included, the unique part count is 71 and total parts is 484. Users are advised to not have their assembly vendor place these components.

--- a/REV20231005F/README.md
+++ b/REV20231005F/README.md
@@ -12,11 +12,11 @@ This folder contains the compiled design outputs for AMDC REV F. This includes t
 | Surface Finish          | Tin Lead         |
 | Silkscreen              | White            |
 | Material                | FR-4, TG150      |
-| Board Thickness	      | 1.6 mm           |
+| Board Thickness         | 1.6 mm           |
 | Min Trace Spacing       | 0.15 mm (6 mil)  |
 | Min Hole Size           | 0.36 mm (14 mil) |
 | Number of Holes         | 1528             |
-| Solder Mask	          | Green            |
+| Solder Mask             | Green            |
 | Finished Copper         | 1 oz             |
 
 ## Assembly Details

--- a/REV20231005F/README.md
+++ b/REV20231005F/README.md
@@ -25,11 +25,12 @@ This folder contains the compiled design outputs for AMDC REV F. This includes t
 |----------------------------|-------------|
 | Unique Part Count[^1]      | 67          |
 | Number of Total Parts[^1]  | 447         |
-| Total SMT Part Count       | 418         |
-| Total Thru Hole Part Count | 29          |
+| Total SMT Part Count       | 415         |
+| Total Thru Hole Part Count | 32          |
 | Total Mechanical Screws    | 13          |
 | Total Mechanical Standoffs | 13          |
 | Total Removable Jumpers    | 10          |
+| Total Picozed              | 1           |
 | BGA / QFN                  | Yes         |
 
 ## Bill of Materials


### PR DESCRIPTION
This PR updates the AMDC [REV20231005F/README.md](https://github.com/Severson-Group/AMDC-Hardware/tree/develop/REV20231005F) to follow a similar format to the AMDS [REV20200920D/README.md](https://github.com/Severson-Group/AMDS/blob/v2.0.x/Mainboard/REV20200920D/README.md)

- Refactors `Board Parameters` and `Assembly Details` tables.
- Adds a `Bill of Materials` section.

##
This PR resolves #249, resolves #254 